### PR TITLE
MNE IO rough draft

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal", 
+        "args": ["--fname", "NDA.mff"]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": false,
+    "python.linting.mypyEnabled": false,
+    "python.linting.pycodestyleEnabled": false,
+    "python.linting.prospectorEnabled": false,
+    "python.linting.pylamaEnabled": false
+}

--- a/base_eeg/main.py
+++ b/base_eeg/main.py
@@ -1,0 +1,33 @@
+import preprocessing
+import mne
+from mne_bids import BIDSPath, write_raw_bids
+from matplotlib import pyplot as plt 
+import argparse, sys, os 
+
+# from mne.datasets import sample
+# from mne_bids import BIDSPath
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Preprocessing Script for EEG Data")
+    parser.add_argument(
+        '--fname', 
+        help="Path to raw EGI file",
+        type=str, 
+    )
+
+    args = parser.parse_args()
+    if not args.fname:
+        parser.print_usage()
+        sys.exit(1)
+
+    raw = preprocessing.read_raw(args.fname)
+    
+    bids_path = BIDSPath(
+        subject="01",
+        session="01",
+        task="testing",
+        run="01", 
+        root="/data/BIDS"
+    )
+    
+    bids = preprocessing.write_bids(raw, bids_path)

--- a/base_eeg/preprocessing.py
+++ b/base_eeg/preprocessing.py
@@ -1,0 +1,25 @@
+import mne
+import os
+from mne_bids import write_raw_bids
+"""
+    Wrapper function to read data from EEG devices as a raw object dependent on
+    raw binary's type. Can be extended to include several eeg data types, such as 
+    BrainVision and EGI. 
+"""
+
+
+def read_raw(fname: str) -> mne.io.Raw:
+    _, ext = os.path.splitext(fname)
+    if(ext == ".mff"):
+        return mne.io.read_raw_egi(fname)
+    else:
+        return
+
+
+
+def write_bids(raw, bids_path):
+    return write_raw_bids(
+        raw, 
+        bids_path,
+        verbose=True 
+    )


### PR DESCRIPTION
able to read from raw EGI data through passing an mff file through the command line with the use of argparse. However, there is also an error from writing bids as a result of the signal1.bin file within the mff file. MNE does not support *.bin types when writing bids. 