### PR TITLE
reflected post-process annotations file will be for each subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ The Preprocessing pipeline assumes that data is already in BIDS format. Thus, an
 
 ### Input/Output .json and .log files
 
-Given that the final pipeline will read from a user-supplied json file called "user_params.json" and write to an annotations file called "annotations_preproc.json" for each subject, all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "annotations_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
+Given that the final pipeline will read from a user-supplied json file called "user_params.json" and write to an output file called "output_preproc.json" for each subject, all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "output_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
 
-The "user_params.json" should control all research-relevant features of the pipeline (e.g. filter cutoffs, segmentation lengths, etc.). The "annotations_preproc.json" output files should contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). Together, the contents of "user_params.json" "annotations_preproc.json" should define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. In fact, the long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "annotations_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
+The "user_params.json" should control all research-relevant features of the pipeline (e.g. filter cutoffs, segmentation lengths, etc.). The "output_preproc.json" output files should contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). Together, the contents of "user_params.json" "output_preproc.json" should define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. In fact, the long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "output_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
 
 
 ### user_params.json
@@ -80,11 +80,11 @@ Format:
 }
 ```
 
-### annotations_preproc_sub_XXX_task_YYY_run_ZZZ.json
+### output_preproc_sub_XXX_task_YYY_run_ZZZ.json
 
-These output annotation files will define which EEG data-set attributes were removed or transformed through the pipeline for each subject. This file will be built iteratively as the pipeline progresses. 
+These output files will define which EEG data-set attributes were removed or transformed through the pipeline for each subject. This file will be built iteratively as the pipeline progresses. 
 
-(please add additional fields as necessary; do not hesitate to add fields. Basically, when working on a feature, if you think there is a value that is computed that might be of use to users, please add it to the "annotations_preproc.json" file.)
+(please add additional fields as necessary; do not hesitate to add fields. Basically, when working on a feature, if you think there is a value that is computed that might be of use to users, please add it to the "output_preproc.json" file.)
 
 Format:
 ```javascript
@@ -117,7 +117,7 @@ logging.info(mne.post.info)
 
 - Feature-badchans
 -auto-detect and remove bad channels (those that are “noisy” for a majority of the recording)
--write to annotations file to indicate which channels were detected as bad (write to field "globalBad_chans")
+-write to output file to indicate which channels were detected as bad (write to field "globalBad_chans")
 
 - Feature-ica
 This feature includes three main (and sequential) steps: 1. Prepica; 2. Ica; 3. Rejica
@@ -128,29 +128,29 @@ Prepica
 -For the copied data: segment/epoch (“cut”) the continuous EEG recording into arbitrary 1-second epochs
 -For the copied data: Use automated methods (voltage outlier detection and spectral outlier detection) to detect epochs -that are excessively “noisy” for any channel
 -For the copied data: reject (remove) the noisy periods of data
--Write to the annotations file which segments were rejected and based on what metrics
+-Write to the output file which segments were rejected and based on what metrics
 Ica
 -For the copied data: run ica
 -Copy the ica weights from the copied data back to the data pre-copy
 Rejica
 -Using automated methods (TBD) identify ica components that reflect artifacts
 -Remove the data corresponding to the ica-identified-artifacts
--Write to the annotations file which ica components were identified as artifacts in the "icArtifacts" field
+-Write to the output file which ica components were identified as artifacts in the "icArtifacts" field
 
 - Feature-segment
 -segment/epoch (cut) the continuous data into epochs of data, such that the zero point for each epoch is a given marker of interest
--write to annotations file which markers were used for epoching purposes, how many of each epoch were created, and how many ms appear before/after the markers of interest
+-write to output file which markers were used for epoching purposes, how many of each epoch were created, and how many ms appear before/after the markers of interest
 
 - Feature-finalrej
 -loop through each channel. For a given channel, loop over all epochs for that channel and identify epochs for which that channel, for a given epoch, exceeds either the voltage threshold or spectral threshold. If it exceeds the threshold, reject the channel data for this channel/epoch.
--write to the annotations file which channel/epoch intersections were rejected
+-write to the output file which channel/epoch intersections were rejected
 
 - Feature-interp
 -interpolate missing channels, at the channel/epoch level using a spherical spline interpolation, as implemented in mne
 -interpolate missing channels, at the global level, using a spherical spline interpolation, as implemented in mne
--write to annotations file which channels were interpolated and using what method
+-write to output file which channels were interpolated and using what method
 
 - Feature-reref
 -re-reference the data to the average of all electrodes (“average reference”) using the mne function
--write to annotations file that data were re-referenced to average
+-write to output file that data were re-referenced to average
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ The Preprocessing pipeline assumes that data is already in BIDS format. Thus, an
 
 ### Input/Output .json and .log files
 
-Given that the final pipeline will read from a user-supplied json file called "user_params.json" and write to an annotations file called "annotations_preproc.json", all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "annotations_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
+Given that the final pipeline will read from a user-supplied json file called "user_params.json" and write to an annotations file called "annotations_preproc.json" for each subject, all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "annotations_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
 
-The "user_params.json" should control all research-relevant features of the pipeline (e.g. filter cutoffs, segmentation lengths, etc.). The "annotations_preproc.json" output file should contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). Together, the contents of "user_params.json" "annotations_preproc.json" should define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. In fact, the long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "annotations_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
+The "user_params.json" should control all research-relevant features of the pipeline (e.g. filter cutoffs, segmentation lengths, etc.). The "annotations_preproc.json" output files should contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). Together, the contents of "user_params.json" "annotations_preproc.json" should define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. In fact, the long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "annotations_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
 
 
 ### user_params.json
 
-This input file will define a set of function parameter constants. The user may define these paremeters within the JSON file to infuence filtering and channel rejection. 
+This singular input file will define a set of function parameter constants. The user may define these paremeters within the JSON file to infuence filtering and channel rejection. 
 
 (please add additional fields as necessary; do not hesitate to add fields. Basically, when working on a feature, if you think there is a parameter that users might want to control, just add another field to the "user_params.json" file. There is no issue with having lots of fields with default values.)
 
@@ -80,9 +80,9 @@ Format:
 }
 ```
 
-### annotations_preproc.json
+### annotations_preproc_sub_XXX_task_YYY_run_ZZZ.json
 
-This output file will define which EEG data-set attributes were removed or transformed through the pipeline. This file will be built iteratively as the pipeline progresses. 
+These output annotation files will define which EEG data-set attributes were removed or transformed through the pipeline for each subject. This file will be built iteratively as the pipeline progresses. 
 
 (please add additional fields as necessary; do not hesitate to add fields. Basically, when working on a feature, if you think there is a value that is computed that might be of use to users, please add it to the "annotations_preproc.json" file.)
 
@@ -94,9 +94,9 @@ Format:
 }
 ```
 
-### output.log
+### output_sub_XXX_task_YYY_run_ZZZ.log
 
-This output file will define the verbose outputs of mne functions including warnings and errors. Format will vary based on pipeline output.
+These output log files will define the verbose outputs of mne functions including warnings and errors for each subject. Format will vary based on pipeline output.
 
 To record function output to log-file, insert the following:
 ```python 


### PR DESCRIPTION
- Update README.md

README may need to eventually be split into two files:

- README.md for general project details
    - pipeline steps
    - annotations file descriptions
  
- [contributing.md](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) for project contributors
    - issue format
    - workflow standards
    - test data
    - CI info