### PR TITLE
split readme into contributing & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # baseEEG
 Lab-wide EEG scripts
 
+![baseeegheader](https://user-images.githubusercontent.com/26397102/117209976-b958e600-adbc-11eb-8f23-d6015a28935e.png)
+
 Development guidelines and details are listed in [contributing.md](contributing.md)
 
 ## Pipeline Steps

--- a/README.md
+++ b/README.md
@@ -3,17 +3,67 @@ Lab-wide EEG scripts
 
 Development guidelines and details are listed in [contributing.md](contributing.md)
 
+## Pipeline Steps:
+
+### 1) Feature-filter
+
+- High pass filter the data using mne function
+- Read in the the "highPass" "lowpass" fields from the "user_params.json" file to define filter parameters
+
+### 2) Feature-badchans
+
+- auto-detect and remove bad channels (those that are “noisy” for a majority of the recording)
+- write to output file to indicate which channels were detected as bad (write to field "globalBad_chans")
+
+### 3) Feature-ica
+
+Overview: ICA requires a decent amount of [stationarity](https://towardsdatascience.com/stationarity-in-time-series-analysis-90c94f27322#:~:text=In%20t%20he%20most%20intuitive,not%20itself%20change%20over%20time.) in the data. This is often violated by raw EEG. 
+    
+One way around this is to first make a copy of the eeg data. For the copy, use automated methods to detect noisy portions of data and remove these sections of data. Run ICA on the copied data after cleaning. Finally, take the ICA weights produced by the copied dataset and copy them back to the recording prior to making a copy (and prior to removing sections of noisy data). In this way, we do not have to “throw out” sections of noisy data, while at the same time, we are able to derive an improved ICA decomposition.
+
+1. Prepica
+    - Make a copy of the eeg recording
+    - For the copied data: high-pass filter at 1 hz
+    - For the copied data: segment/epoch (“cut”) the continuous EEG recording into arbitrary 1-second epochs
+    - For the copied data: Use automated methods (voltage outlier detection and spectral outlier detection) to detect epochs -that are excessively “noisy” for any channel
+    - For the copied data: reject (remove) the noisy periods of data
+    - Write to the output file which segments were rejected and based on what metrics
+2. Ica
+    - For the copied data: run ica
+    - Copy the ica weights from the copied data back to the data pre-copy
+3. Rejica
+    - Using automated methods (TBD) identify ica components that reflect artifacts
+    - Remove the data corresponding to the ica-identified-artifacts
+    - Write to the output file which ica components were identified as artifacts in the "icArtifacts" field
+
+### 4) Feature-segment
+- segment/epoch (cut) the continuous data into epochs of data, such that the zero point for each epoch is a given marker of interest
+- write to output file which markers were used for epoching purposes, how many of each epoch were created, and how many ms appear before/after the markers of interest
+
+### 5) Feature-finalrej
+- loop through each channel. For a given channel, loop over all epochs for that channel and identify epochs for which that channel, for a given epoch, exceeds either the voltage threshold or spectral threshold. If it exceeds the threshold, reject the channel data for this channel/epoch.
+- write to the output file which channel/epoch intersections were rejected
+
+### 6) Feature-interp
+- interpolate missing channels, at the channel/epoch level using a spherical spline interpolation, as implemented in mne
+- interpolate missing channels, at the global level, using a spherical spline interpolation, as implemented in mne
+- write to output file which channels were interpolated and using what method
+
+### 7) Feature-reref
+- re-reference the data to the average of all electrodes (“average reference”) using the mne function
+- write to output file that data were re-referenced to average
+
 ## Input/Output Files
 
-The pipeline reads from a user-supplied json file called [user_params.json](#user_params.json) and writes to many output files called [output_preproc_sub_XXX_task_YYY_run_ZZZ.json](#output_preproc_sub_XXX_task_YYY_run_ZZZ.json) and [output_sub_XXX_task_YYY_run_ZZZ.log](#output_sub_XXX_task_YYY_run_ZZZ.log) for each subject.
+The pipeline reads from a user-supplied json file called [user_params.json](#user_params.json) and writes to many output files called [output_preproc.json](#output_preproc.json) and [output.log](#output_sub.log) for each subject
 
-Together, the contents of [user_params.json](#user_params.json) and [output_preproc_sub_XXX_task_YYY_run_ZZZ.json](#output_preproc_sub_XXX_task_YYY_run_ZZZ.json) define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. 
+Together, the contents of [user_params.json](#user_params.json) and [output_preproc.json](#output_preproc.json) define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were
 
-The long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "output_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
+The long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "output_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc
 
 ### user_params.json
 
-This singular input file defines all research-relevant features of the pipeline. The user may define these paremeters within the JSON file to infuence filtering and channel rejection.
+This singular input file defines all research-relevant features of the pipeline. The user may define these paremeters within the JSON file to infuence filtering and channel rejection
 
 Format:
 ```javascript
@@ -23,9 +73,11 @@ Format:
 }
 ```
 
-### output_preproc_sub_XXX_task_YYY_run_ZZZ.json
+### output_preproc.json
 
-These output files will contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). This file will be built iteratively as the pipeline progresses. 
+These output files will contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). This file will be built iteratively as the pipeline progresses
+
+Each file name generated on a subject will follow the BIDS naming standard: `output_preproc_XXX_task_YYY_run_ZZZ.json`
 
 Format:
 ```javascript
@@ -35,56 +87,10 @@ Format:
 }
 ```
 
-### output_sub_XXX_task_YYY_run_ZZZ.log
+### output_sub.log
 
-These output log files will define the verbose outputs of mne functions including warnings and errors for each subject. Format will vary based on pipeline output.
+These output log files will define the verbose outputs of mne functions including warnings and errors for each subject. Format will vary based on pipeline output
 
-## Steps of the pipline:
+Each file name generated on a subject will follow the BIDS naming standard: `output_XXX_task_YYY_run_ZZZ.log`
 
-1. Feature-filter
-    - High pass filter the data using mne function
-    - Read in the the "highPass" "lowpass" fields from the "user_params.json" file to define filter parameters
-
-2. Feature-badchans
-    - auto-detect and remove bad channels (those that are “noisy” for a majority of the recording)
-    - write to output file to indicate which channels were detected as bad (write to field "globalBad_chans")
-
-3. Feature-ica
-
-    Overview: ICA requires a decent amount of [stationarity](https://towardsdatascience.com/stationarity-in-time-series-analysis-90c94f27322#:~:text=In%20t%20he%20most%20intuitive,not%20itself%20change%20over%20time.) in the data. This is often violated by raw EEG. 
-    
-    One way around this is to first make a copy of the eeg data. For the copy, use automated methods to detect noisy portions of data and remove these sections of data. Run ICA on the copied data after cleaning. Finally, take the ICA weights produced by the copied dataset and copy them back to the recording prior to making a copy (and prior to removing sections of noisy data). In this way, we do not have to “throw out” sections of noisy data, while at the same time, we are able to derive an improved ICA decomposition.
-
-    This feature includes three main sequential steps: 
-    1. Prepica
-        - Make a copy of the eeg recording
-        - For the copied data: high-pass filter at 1 hz
-        - For the copied data: segment/epoch (“cut”) the continuous EEG recording into arbitrary 1-second epochs
-        - For the copied data: Use automated methods (voltage outlier detection and spectral outlier detection) to detect epochs -that are excessively “noisy” for any channel
-        - For the copied data: reject (remove) the noisy periods of data
-        - Write to the output file which segments were rejected and based on what metrics
-    2. Ica
-        - For the copied data: run ica
-        - Copy the ica weights from the copied data back to the data pre-copy
-    3. Rejica
-        - Using automated methods (TBD) identify ica components that reflect artifacts
-        - Remove the data corresponding to the ica-identified-artifacts
-        - Write to the output file which ica components were identified as artifacts in the "icArtifacts" field
-
-4. Feature-segment
-    - segment/epoch (cut) the continuous data into epochs of data, such that the zero point for each epoch is a given marker of interest
-    - write to output file which markers were used for epoching purposes, how many of each epoch were created, and how many ms appear before/after the markers of interest
-
-5. Feature-finalrej
-    - loop through each channel. For a given channel, loop over all epochs for that channel and identify epochs for which that channel, for a given epoch, exceeds either the voltage threshold or spectral threshold. If it exceeds the threshold, reject the channel data for this channel/epoch.
-    - write to the output file which channel/epoch intersections were rejected
-
-6. Feature-interp
-    - interpolate missing channels, at the channel/epoch level using a spherical spline interpolation, as implemented in mne
-    - interpolate missing channels, at the global level, using a spherical spline interpolation, as implemented in mne
-    - write to output file which channels were interpolated and using what method
-
-7. Feature-reref
-    - re-reference the data to the average of all electrodes (“average reference”) using the mne function
-    - write to output file that data were re-referenced to average
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Lab-wide EEG scripts
 
 Development guidelines and details are listed in [contributing.md](contributing.md)
 
-## Pipeline Steps:
+## Pipeline Steps
 
 ### 1) Feature-filter
 

--- a/README.md
+++ b/README.md
@@ -1,70 +1,13 @@
 # baseEEG
 Lab-wide EEG scripts
 
-If working on development for this project, please use the docker image located at `base_eeg_docker_files/`. Directions on installation and usage located in `base_eeg_docker_files/README.md`. 
-
-
-## Issues
-
-See issues for current/future work. 
-
-Always assign yourself to an issue before beginning work on it!
-
-If someone is already assigned to an issue, but you want to help, post a comment to ask if you can help before assigning yourself. If no response within 24 hours, then you are free to start work on the issue, but post another comment first to let them know what you will be doing.
-
-
-## Git Workflow 
-
-![ndcworkflow](https://user-images.githubusercontent.com/26397102/116148813-00512800-a6a7-11eb-9624-cd81f11d3ada.png)
-
-
-Folder/branch organization should follow this convention:
-
-`main`
-- no test features
-- 100% stable and usable by any lab members 
-- *no direct commits*
-
-`->dev`
-- Up to date development branch with properly tested/reviewed features 
-- *no direct commits*
-
-`-->dev-feature-[featureName]`
-- Ongoing development and testing of feature to be pull requested into `dev` 
-- *no direct commits*
-
-`--->dev-feature-[featureName]-[yourName]`
-- *only* branch available for personal development, must be branched off of `-->dev-feature-[featureName]` branch
-- Merged into `-->dev-feature-[featureName]` after pull-request (code review)
-
-
-## Reminders
-1. only push directly (without code review) to dev-feature-[featureName]=[yourName]
-2. Must initiate pull request (and assign at least one person) for any higher-level branch
-3. Mandatory code review by one person for all pull requests 
-
-
-## CI test
-NDCLab CI test documentation: https://docs.google.com/document/d/1lTYCLn6XK4Ln-BjcNhMMqpQFhYWg6OHB/edit
-
-
-## Example File for Development
-- [BIDS.zip](https://drive.google.com/drive/u/0/folders/1aQY97T9EfkPEkuiCav2ei9cs0DFegO4-) is used as input file for all pipeline features.
-
-
-## Roadmap
-
-All features (pipeline steps) can and should be worked on independently and in parallel. Any steps for which implementation relied on a prior step first being completed have been merged into one single feature (e.g., feature-ica contains three steps that must be implemented sequentially). Please self-assign to any feature, read the relevant documentation, reach out with questions, and begin implementation. There is no correct order to implement any of these steps.
-
-The Preprocessing pipeline assumes that data is already in BIDS format. Thus, any scripts (e.g. feature-filter-io) to convert data to BIDS format are NOT part of the preprocessing pipeline. Thus, all steps of the preprocessing pipeline should be written in such a way as to assume a BIDS folder structure file already exists and that standard BIDS metadata files exist (which can be read in to govern preprocessing). Moreover, all outputs of the preprocessing stream should either be in line with existing BIDS standards or if they relate to a feature that there is not yet a BIDS standard for, the developer should set things up in a way that is in line with general BIDS principles.
-
+Development details are listed in [contributing.md](contributing.md)
 
 ### Input/Output .json and .log files
 
-Given that the final pipeline will read from a user-supplied json file called "user_params.json" and write to an output file called "output_preproc.json" for each subject, all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "output_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
+The pipeline reads from a user-supplied json file called "user_params.json" and write to an output file called "output_preproc.json" for each subject, all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "output_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
 
 The "user_params.json" should control all research-relevant features of the pipeline (e.g. filter cutoffs, segmentation lengths, etc.). The "output_preproc.json" output files should contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). Together, the contents of "user_params.json" "output_preproc.json" should define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. In fact, the long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "output_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
-
 
 ### user_params.json
 
@@ -109,48 +52,52 @@ logging.info("describe output of pipeline")
 # record pipeline output
 logging.info(mne.post.info)
 ```
-### Steps/features of the pipline:
+### Steps of the pipline:
 
-- Feature-filter
--High pass filter the data using mne function
--Read in the the "highPass" "lowpass" fields from the "user_params.json" file to define filter parameters
+1. Feature-filter
+    - High pass filter the data using mne function
+    - Read in the the "highPass" "lowpass" fields from the "user_params.json" file to define filter parameters
 
-- Feature-badchans
--auto-detect and remove bad channels (those that are “noisy” for a majority of the recording)
--write to output file to indicate which channels were detected as bad (write to field "globalBad_chans")
+2. Feature-badchans
+    - auto-detect and remove bad channels (those that are “noisy” for a majority of the recording)
+    - write to output file to indicate which channels were detected as bad (write to field "globalBad_chans")
 
-- Feature-ica
-This feature includes three main (and sequential) steps: 1. Prepica; 2. Ica; 3. Rejica
-Overview: ICA requires a decent amount of stationarity in the data. This is often violated by raw EEG. One way around this is to first make a copy of the eeg data. For the copy, use automated methods to detect noisy portions of data and remove these sections of data. Run ICA on the copied data after cleaning. Finally, take the ICA weights produced by the copied dataset and copy them back to the recording prior to making a copy (and prior to removing sections of noisy data). In this way, we do not have to “throw out” sections of noisy data, while at the same time, we are able to derive an improved ICA decomposition.
-Prepica
--Make a copy of the eeg recording
--For the copied data: high-pass filter at 1 hz
--For the copied data: segment/epoch (“cut”) the continuous EEG recording into arbitrary 1-second epochs
--For the copied data: Use automated methods (voltage outlier detection and spectral outlier detection) to detect epochs -that are excessively “noisy” for any channel
--For the copied data: reject (remove) the noisy periods of data
--Write to the output file which segments were rejected and based on what metrics
-Ica
--For the copied data: run ica
--Copy the ica weights from the copied data back to the data pre-copy
-Rejica
--Using automated methods (TBD) identify ica components that reflect artifacts
--Remove the data corresponding to the ica-identified-artifacts
--Write to the output file which ica components were identified as artifacts in the "icArtifacts" field
+3. Feature-ica
 
-- Feature-segment
--segment/epoch (cut) the continuous data into epochs of data, such that the zero point for each epoch is a given marker of interest
--write to output file which markers were used for epoching purposes, how many of each epoch were created, and how many ms appear before/after the markers of interest
+    Overview: ICA requires a decent amount of [stationarity](https://towardsdatascience.com/stationarity-in-time-series-analysis-90c94f27322#:~:text=In%20t%20he%20most%20intuitive,not%20itself%20change%20over%20time.) in the data. This is often violated by raw EEG. 
+    
+    One way around this is to first make a copy of the eeg data. For the copy, use automated methods to detect noisy portions of data and remove these sections of data. Run ICA on the copied data after cleaning. Finally, take the ICA weights produced by the copied dataset and copy them back to the recording prior to making a copy (and prior to removing sections of noisy data). In this way, we do not have to “throw out” sections of noisy data, while at the same time, we are able to derive an improved ICA decomposition.
 
-- Feature-finalrej
--loop through each channel. For a given channel, loop over all epochs for that channel and identify epochs for which that channel, for a given epoch, exceeds either the voltage threshold or spectral threshold. If it exceeds the threshold, reject the channel data for this channel/epoch.
--write to the output file which channel/epoch intersections were rejected
+    This feature includes three main sequential steps: 
+    1. Prepica
+        - Make a copy of the eeg recording
+        - For the copied data: high-pass filter at 1 hz
+        - For the copied data: segment/epoch (“cut”) the continuous EEG recording into arbitrary 1-second epochs
+        - For the copied data: Use automated methods (voltage outlier detection and spectral outlier detection) to detect epochs -that are excessively “noisy” for any channel
+        - For the copied data: reject (remove) the noisy periods of data
+        - Write to the output file which segments were rejected and based on what metrics
+    2. Ica
+        - For the copied data: run ica
+        - Copy the ica weights from the copied data back to the data pre-copy
+    3. Rejica
+        - Using automated methods (TBD) identify ica components that reflect artifacts
+        - Remove the data corresponding to the ica-identified-artifacts
+        - Write to the output file which ica components were identified as artifacts in the "icArtifacts" field
 
-- Feature-interp
--interpolate missing channels, at the channel/epoch level using a spherical spline interpolation, as implemented in mne
--interpolate missing channels, at the global level, using a spherical spline interpolation, as implemented in mne
--write to output file which channels were interpolated and using what method
+4. Feature-segment
+    - segment/epoch (cut) the continuous data into epochs of data, such that the zero point for each epoch is a given marker of interest
+    - write to output file which markers were used for epoching purposes, how many of each epoch were created, and how many ms appear before/after the markers of interest
 
-- Feature-reref
--re-reference the data to the average of all electrodes (“average reference”) using the mne function
--write to output file that data were re-referenced to average
+5. Feature-finalrej
+    - loop through each channel. For a given channel, loop over all epochs for that channel and identify epochs for which that channel, for a given epoch, exceeds either the voltage threshold or spectral threshold. If it exceeds the threshold, reject the channel data for this channel/epoch.
+    - write to the output file which channel/epoch intersections were rejected
+
+6. Feature-interp
+    - interpolate missing channels, at the channel/epoch level using a spherical spline interpolation, as implemented in mne
+    - interpolate missing channels, at the global level, using a spherical spline interpolation, as implemented in mne
+    - write to output file which channels were interpolated and using what method
+
+7. Feature-reref
+    - re-reference the data to the average of all electrodes (“average reference”) using the mne function
+    - write to output file that data were re-referenced to average
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # baseEEG
 Lab-wide EEG scripts
 
-Development details are listed in [contributing.md](contributing.md)
+Development guidelines and details are listed in [contributing.md](contributing.md)
 
-### Input/Output .json and .log files
+## Input/Output Files
 
-The pipeline reads from a user-supplied json file called "user_params.json" and write to an output file called "output_preproc.json" for each subject, all independent feature development should refer to a common standard format for these two files to allow for easier integration of features for the final pipeline. In addition to the "output_preproc.json" output file, all features should all provide more verbose writing of outputs to an output.log file.
+The pipeline reads from a user-supplied json file called [user_params.json](#user_params.json) and writes to many output files called [output_preproc_sub_XXX_task_YYY_run_ZZZ.json](#output_preproc_sub_XXX_task_YYY_run_ZZZ.json) and [output_sub_XXX_task_YYY_run_ZZZ.log](#output_sub_XXX_task_YYY_run_ZZZ.log) for each subject.
 
-The "user_params.json" should control all research-relevant features of the pipeline (e.g. filter cutoffs, segmentation lengths, etc.). The "output_preproc.json" output files should contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). Together, the contents of "user_params.json" "output_preproc.json" should define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. In fact, the long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "output_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
+Together, the contents of [user_params.json](#user_params.json) and [output_preproc_sub_XXX_task_YYY_run_ZZZ.json](#output_preproc_sub_XXX_task_YYY_run_ZZZ.json) define all details neccesary to write relevant methods and results section for a journal publication to describe what the preprocessing pipeline did and what the outputs were. 
+
+The long term goal is to automate the writing of these journal article sections via a script that takes "user_params.json" and "output_preproc.json" as inputs. In contrast, the output.log file reflects a much more verbose record of what was run, what the outputs were, and the pressence of any warning/errors, etc. 
 
 ### user_params.json
 
-This singular input file will define a set of function parameter constants. The user may define these paremeters within the JSON file to infuence filtering and channel rejection. 
-
-(please add additional fields as necessary; do not hesitate to add fields. Basically, when working on a feature, if you think there is a parameter that users might want to control, just add another field to the "user_params.json" file. There is no issue with having lots of fields with default values.)
+This singular input file defines all research-relevant features of the pipeline. The user may define these paremeters within the JSON file to infuence filtering and channel rejection.
 
 Format:
 ```javascript
@@ -25,9 +25,7 @@ Format:
 
 ### output_preproc_sub_XXX_task_YYY_run_ZZZ.json
 
-These output files will define which EEG data-set attributes were removed or transformed through the pipeline for each subject. This file will be built iteratively as the pipeline progresses. 
-
-(please add additional fields as necessary; do not hesitate to add fields. Basically, when working on a feature, if you think there is a value that is computed that might be of use to users, please add it to the "output_preproc.json" file.)
+These output files will contain all research-relevant outputs of the pipeline (e.g. # bad channels rejected, # ICA artifacts rejected, etc.). This file will be built iteratively as the pipeline progresses. 
 
 Format:
 ```javascript
@@ -41,18 +39,7 @@ Format:
 
 These output log files will define the verbose outputs of mne functions including warnings and errors for each subject. Format will vary based on pipeline output.
 
-To record function output to log-file, insert the following:
-```python 
-# initialize log-file
-logging.basicConfig(filename='output.log', filemode='a', encoding='utf-8', level=logging.NOTSET)
-
-# ... pipeline steps execute ...
-
-logging.info("describe output of pipeline")
-# record pipeline output
-logging.info(mne.post.info)
-```
-### Steps of the pipline:
+## Steps of the pipline:
 
 1. Feature-filter
     - High pass filter the data using mne function

--- a/contributing.md
+++ b/contributing.md
@@ -58,10 +58,23 @@ Subsequently, branches follow this convention:
 [NDCLab CI test documentation](https://docs.google.com/document/d/1lTYCLn6XK4Ln-BjcNhMMqpQFhYWg6OHB/edit)
 
 ## Input-Data
-- For development, [BIDS.zip](https://drive.google.com/drive/u/0/folders/1aQY97T9EfkPEkuiCav2ei9cs0DFegO4-) is used as the test input file for all pipeline features.
-- 
+- [BIDS.zip](https://drive.google.com/drive/u/0/folders/1aQY97T9EfkPEkuiCav2ei9cs0DFegO4-) is used as the test input file for all pipeline feature development. 
+- [user_params.json](README.md)
 
 ## Output-Data
+- [output_preproc_sub_XXX_task_YYY_run_ZZZ.json](README.md)
+- [output_sub_XXX_task_YYY_run_ZZZ.log](README.md)
+    To record function output to log-file, insert the following:
+    ```python 
+    # initialize log-file
+    logging.basicConfig(filename=subject_file_name, filemode='a', encoding='utf-8', level=logging.NOTSET)
+
+    # ... pipeline steps execute ...
+
+    logging.info("describe output of pipeline")
+    # record pipeline output
+    logging.info(mne.post.info)
+    ```
 
 ## Reminders
 1. only push directly (without code review) to dev-feature-[featureName]-[yourName]

--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,6 @@
 # baseEEG contributing docs & standards
 Welcome to baseEEG! The guidelines for development are as follows: 
 
-#### Table of Contents
 * [Roadmap](#Roadmap)  
 * [Containers](#Containers)
 * [Issues](#Issues)  

--- a/contributing.md
+++ b/contributing.md
@@ -62,8 +62,8 @@ Subsequently, branches follow this convention:
 - [user_params.json](README.md)
 
 ## Output-Data
-- [output_preproc_sub_XXX_task_YYY_run_ZZZ.json](README.md)
-- [output_sub_XXX_task_YYY_run_ZZZ.log](README.md)
+- [output_preproc.json](README.md)
+- [output.log](README.md)
     To record function output to log-file, insert the following:
     ```python 
     # initialize log-file

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,70 @@
+# baseEEG contributing docs & standards
+Welcome to baseEEG! The guidelines for development are as follows: 
+
+#### Table of Contents
+* [Roadmap](#Roadmap)  
+* [Containers](#Containers)
+* [Issues](#Issues)  
+* [Git-Workflow](#Git-Workflow)  
+* [CI-test](#CI-test)  
+* [Input-Data](#Input-Data)  
+* [Output-Data](#Output-Data)
+* [Reminders](#Reminders)  
+
+## Roadmap
+
+All features (pipeline steps) can be worked on independently and in parallel. Any steps for which implementation relied on a prior step first being completed have been merged into one single feature (e.g., feature-ica contains three steps that must be implemented sequentially). Please self-assign to any feature, read the relevant documentation, reach out with questions, and begin implementation. There is no correct order to implement any of these steps.
+
+The Preprocessing pipeline assumes that data is already in BIDS format. Thus, any scripts (e.g. feature-filter-io) to convert data to BIDS format are NOT part of the preprocessing pipeline. Thus, all steps of the preprocessing pipeline should be written in such a way as to assume a BIDS folder structure file already exists and that standard BIDS metadata files exist (which can be read in to govern preprocessing). 
+
+## Containers
+
+Please use the docker image located at `base_eeg_docker_files/`. Directions on installation and usage located in `base_eeg_docker_files/README.md`. 
+
+## Issues
+
+See issues for current/future work. 
+
+Always assign yourself to an issue before beginning work on it!
+
+If someone is already assigned to an issue that you intend to work on, post a comment to ask if you can help before assigning yourself. If no response within 24 hours, then you are free to start work on the issue, but post another comment first to let them know what you will be doing.
+
+## Git-Workflow 
+
+![ndcworkflow](https://user-images.githubusercontent.com/26397102/116148813-00512800-a6a7-11eb-9624-cd81f11d3ada.png)
+
+Development is driven by the [feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow), where each new feature is encapsulated in a branch. This ensures changes are properly tested & integrated while still allowing for development to be done in parallel
+
+Subsequently, branches follow this convention:
+
+`main`
+- no test features
+- 100% stable and usable by any lab members 
+- *no direct commits*
+
+`->dev`
+- Up to date development branch with properly tested/reviewed features 
+- *no direct commits*
+
+`-->dev-feature-[featureName]`
+- Ongoing development and testing of feature to be pull requested into `dev` 
+- *no direct commits*
+
+`--->dev-feature-[featureName]-[yourName]`
+- *only* branch available for personal development, must be branched off of `-->dev-feature-[featureName]` branch
+- Merged into `-->dev-feature-[featureName]` after pull-request (code review)
+
+## CI-test
+[NDCLab CI test documentation](https://docs.google.com/document/d/1lTYCLn6XK4Ln-BjcNhMMqpQFhYWg6OHB/edit)
+
+## Input-Data
+- For development, [BIDS.zip](https://drive.google.com/drive/u/0/folders/1aQY97T9EfkPEkuiCav2ei9cs0DFegO4-) is used as the test input file for all pipeline features.
+- 
+
+## Output-Data
+
+## Reminders
+1. only push directly (without code review) to dev-feature-[featureName]-[yourName]
+2. Must initiate pull request (and assign at least one person) for any higher-level branch
+3. Mandatory code review by one person for all pull requests 
+4. If there is no BIDS standard for a type of file that a feature outputs, the developer should set things up in a way that is in line with [general BIDS principles](https://www.nature.com/articles/s41597-019-0104-8).


### PR DESCRIPTION
Resolves #82.

- Condensed documentation where possible
- Put front-facing research-focused docs in readme
- Put back-facing developer-focused docs in contributing

