### PR TITLE
Subtract 1 sample from each segment end time when importing MFF into BIDS format.

### DIFF
--- a/base_eeg/import_example_data.py
+++ b/base_eeg/import_example_data.py
@@ -82,6 +82,10 @@ block_df['end_time'] = np.roll(block_df['start_time'], -1)
 block_df.loc[0, 'start_time'] = 0
 block_df.loc[block_df.index[-1], 'end_time'] = raw.times[-1]
 
+# subtract an amount of time equal to 1 sample from each end time
+# to avoid the next annotation from being included in cropped data
+block_df['end_time'] = block_df['end_time'] - (1 / raw.info['sfreq'])
+
 block_df['run'] = block_df.groupby('code').cumcount() + 1
 
 # write out each block as a separate file

--- a/base_eeg/import_example_data.py
+++ b/base_eeg/import_example_data.py
@@ -93,7 +93,7 @@ for b in block_df.index:
     raw_cropped = raw.copy().crop(tmin=block_df.loc[b, 'start_time'],
                                   tmax=block_df.loc[b, 'end_time'],
                                   include_tmax=False)
-    temp_path = pathlib.Path.cwd() / (task_name + '_' + run_number + '_raw.fif')
+    temp_path = pathlib.Path.cwd() / f'{task_name}_{run_number}_raw.fif'
     raw_cropped.save(temp_path, overwrite=True)
 
     # read .fif back and write BIDS
@@ -118,6 +118,6 @@ for b in block_df.index:
 
 # update participants.tsv
 participant_data = pd.read_csv(bids_root / 'participants.tsv', sep='\t')
-participant_data.loc[participant_data['participant_id'] == 'sub-' + participant_code, 'age'] = participant_age
-participant_data.loc[participant_data['participant_id'] == 'sub-' + participant_code, 'sex'] = participant_sex
+participant_data.loc[participant_data['participant_id'] == f'sub-{participant_code}', 'age'] = participant_age
+participant_data.loc[participant_data['participant_id'] == f'sub-{participant_code}', 'sex'] = participant_sex
 participant_data.to_csv(bids_root / 'participants.tsv', sep='\t')

--- a/base_eeg/import_example_data.py
+++ b/base_eeg/import_example_data.py
@@ -11,18 +11,18 @@ bids_root = pathlib.Path.cwd() / 'BIDS'
 meta_data = pd.read_csv(pathlib.Path.cwd() / 'HBN_R2_1_Pheno.csv')
 
 # mapping of event codes to block starts
-block_mapping = {90: 'RestingState',
-                91: 'SequenceLearning',
-                92: 'SymbolSearch',
-                93: 'SurrSuppBlock1',
-                94: 'ContrastChangeBlock1',
-                95: 'ContrastChangeBlock2',
-                96: 'ContrastChangeBlock3',
-                97: 'SurrSuppBlock2',
-                81: 'Video1',
-                82: 'Video2',
-                83: 'Video3',
-                84: 'Video4'}
+block_mapping = {'90': 'RestingState',
+                 '91': 'SequenceLearning',
+                 '92': 'SymbolSearch',
+                 '93': 'SurrSuppBlock1',
+                 '94': 'ContrastChangeBlock1',
+                 '95': 'ContrastChangeBlock2',
+                 '96': 'ContrastChangeBlock3',
+                 '97': 'SurrSuppBlock2',
+                 '81': 'Video1',
+                 '82': 'Video2',
+                 '83': 'Video3',
+                 '84': 'Video4'}
 
 # TODO: double check that the sex mapping is correct
 sex_mapping = {0: 'F',
@@ -59,7 +59,7 @@ event_keys = raw.event_id
 # extract the events from the 'STI 014' composite channel
 events = mne.find_events(raw, stim_channel='STI 014', shortest_event=1)
 # reverse the dict so that the keys are items and items are keys, stripping any trailing whitespace from the event strings
-event_map = dict((v,k.rstrip()) for k,v in event_keys.items())
+event_map = dict((v, k.rstrip()) for k, v in event_keys.items())
 # use the event numpy array with integers, and the event_map going from integer to string names, to create annotations with the correct labels
 event_annotations = mne.annotations_from_events(events=events, sfreq=raw.info['sfreq'],
                                                 orig_time=raw.info['meas_date'], event_desc=event_map)
@@ -68,35 +68,31 @@ raw.set_annotations(raw.annotations + event_annotations)
 # keep only the EEG channels, removing the stimulation channels
 raw.pick_types(eeg=True)
 
-# get events from the annotations and convert to integers on load
-events = mne.events_from_annotations(raw, int)
-events_onset = events[0]
+# get the time and code for each annotation
+annotation_codes = [(a['onset'], a['description']) for a in raw.annotations]
 
-# reduce to only the events that indicate block starts
-block_events = events_onset[np.isin(events_onset[:,2], list(block_mapping)),:]
-block_df = pd.DataFrame(data=block_events[:,[0,2]], columns=['start_sample', 'event'])
+# reduce to only the annotations that indicate block starts
+block_annotations = [a for a in annotation_codes if np.isin(a[1], list(block_mapping))]
+block_df = pd.DataFrame(data=block_annotations, columns=['start_time', 'code'])
 
 # each block end is the time of the next block start
-# the first block starts at 0, the final block ends at the maximum of the recording
-block_df['end_sample'] = np.roll(block_df['start_sample'], -1)
+block_df['end_time'] = np.roll(block_df['start_time'], -1)
 
 # extend the length of the first and last block periods to the start / end of the recording
-block_df.loc[0, 'start_sample'] = 0
-block_df.loc[block_df.index[-1], 'end_sample'] = raw.n_times - 1
+block_df.loc[0, 'start_time'] = 0
+block_df.loc[block_df.index[-1], 'end_time'] = raw.times[-1]
 
-block_df['start_time'] = block_df['start_sample'] / raw.info['sfreq']
-block_df['end_time'] = block_df['end_sample'] / raw.info['sfreq']
-
-block_df['run'] = block_df.groupby('event').cumcount()+1
+block_df['run'] = block_df.groupby('code').cumcount() + 1
 
 # write out each block as a separate file
 for b in block_df.index:
-
-    task_name = block_mapping[block_df.loc[b, 'event']]
+    task_name = block_mapping[block_df.loc[b, 'code']]
     run_number = str(block_df.loc[b, 'run']).zfill(2)
 
-    # crop & convert sample point into seconds & save as .fif
-    raw_cropped = raw.copy().crop(tmin=block_df.loc[b, 'start_time'], tmax=block_df.loc[b, 'end_time'], include_tmax=False)
+    # crop & save as .fif
+    raw_cropped = raw.copy().crop(tmin=block_df.loc[b, 'start_time'],
+                                  tmax=block_df.loc[b, 'end_time'],
+                                  include_tmax=False)
     temp_path = pathlib.Path.cwd() / (task_name + '_' + run_number + '_raw.fif')
     raw_cropped.save(temp_path, overwrite=True)
 
@@ -124,5 +120,4 @@ for b in block_df.index:
 participant_data = pd.read_csv(bids_root / 'participants.tsv', sep='\t')
 participant_data.loc[participant_data['participant_id'] == 'sub-' + participant_code, 'age'] = participant_age
 participant_data.loc[participant_data['participant_id'] == 'sub-' + participant_code, 'sex'] = participant_sex
-participant_data.to_csv(bids_root / 'participants.tsv',  sep='\t')
-
+participant_data.to_csv(bids_root / 'participants.tsv', sep='\t')


### PR DESCRIPTION
We identified that the `crop` function in MNE seems to include annotations from 1 sample after the last data point cropped. When segmenting our MFF recording into smaller task specific recordings, this was generating a warning on BIDS import, as annotations existed beyond the limits of the data. This pull request refactors some of the logic around selecting the time segments to crop, and decreases the size of our BIDS formatted task recordings by 1 sample each to avoid the BIDS import warning.