### PR TITLE
Updated bids test to check all files

### DIFF
--- a/base_eeg/bids_test.py
+++ b/base_eeg/bids_test.py
@@ -1,10 +1,30 @@
-import unittest
+from pathlib import Path
+
+from mne_bids import BIDSPath
 from bids_validator import BIDSValidator
+
+import unittest
 
 
 class BidsTest(unittest.TestCase):
+    def setUp(self):
+        # init validator
+        self.validator = BIDSValidator()
+
+        # get all available BIDS files
+        bids_root = Path('BIDS')
+        bids_path = BIDSPath(
+            datatype='eeg',
+            root=bids_root
+        )
+        # init list of BIDS files
+        self.files = map(str, bids_path.match())
+
     def test_if_valid(self):
-        self.assertTrue(BIDSValidator.is_bids("BIDS"))
+        for file in self.files:
+            print(file)
+            self.assertTrue(self.validator.is_bids(file[4:]),
+                            msg="BIDS validate failed on file" + str(file[4:]))
 
 
 if __name__ == '__main__':

--- a/base_eeg/bids_test.py
+++ b/base_eeg/bids_test.py
@@ -7,6 +7,22 @@ import unittest
 
 
 class BidsTest(unittest.TestCase):
+    """Testing module that validates BIDS format and files
+
+    Instance Variables
+    ----------
+    self.validator: BIDSValidator()
+        BIDSValidator object
+
+    self.files: list
+        list that contains all data files from BIDS directory
+
+    Public Methods
+    ----------
+    test_if_valid()
+        verbose method that checks if each BIDS file is in proper format
+
+    """
     def setUp(self):
         # init validator
         self.validator = BIDSValidator()
@@ -22,7 +38,7 @@ class BidsTest(unittest.TestCase):
 
     def test_if_valid(self):
         for file in self.files:
-            print(file)
+            print("checking", file)
             self.assertTrue(self.validator.is_bids(file[4:]),
                             msg="BIDS validate failed on file" + str(file[4:]))
 

--- a/base_eeg/bids_test.py
+++ b/base_eeg/bids_test.py
@@ -1,0 +1,11 @@
+import unittest
+from bids_validator import BIDSValidator
+
+
+class BidsTest(unittest.TestCase):
+    def test_if_valid(self):
+        self.assertTrue(BIDSValidator.is_bids("BIDS"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/base_eeg/bids_test.py
+++ b/base_eeg/bids_test.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from os import walk, listdir
-from os.path import isfile, join
+from os import walk
+from os.path import join
 
 from bids_validator import BIDSValidator
 

--- a/base_eeg/bids_test.py
+++ b/base_eeg/bids_test.py
@@ -1,6 +1,7 @@
 from pathlib import Path
+from os import walk, listdir
+from os.path import isfile, join
 
-from mne_bids import BIDSPath
 from bids_validator import BIDSValidator
 
 import unittest
@@ -27,16 +28,15 @@ class BidsTest(unittest.TestCase):
         # init validator
         self.validator = BIDSValidator()
 
-        # get all available BIDS files
-        bids_root = Path('BIDS')
-        bids_path = BIDSPath(
-            datatype='eeg',
-            root=bids_root
-        )
-        # init list of BIDS files
-        self.files = map(str, bids_path.match())
+        root = Path('BIDS')
+        self.files = []
+        # "walk" through BIDS directory and append all found files
+        for (dirpath, dirnames, filenames) in walk(root):
+            path_filenames = [join(dirpath, name) for name in filenames]
+            self.files += path_filenames
 
     def test_if_valid(self):
+        # for each file found, inspect if BIDS
         for file in self.files:
             print("checking", file)
             self.assertTrue(self.validator.is_bids(file[4:]),

--- a/base_eeg/bids_test.py
+++ b/base_eeg/bids_test.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from os import walk
+from os import walk, sep
 from os.path import join
 
 from bids_validator import BIDSValidator
@@ -18,6 +18,9 @@ class BidsTest(unittest.TestCase):
     self.files: list
         list that contains all data files from BIDS directory
 
+    self.root: str
+        BIDS directory root
+
     Public Methods
     ----------
     test_if_valid()
@@ -28,19 +31,22 @@ class BidsTest(unittest.TestCase):
         # init validator
         self.validator = BIDSValidator()
 
-        root = Path('BIDS')
+        self.root = Path('BIDS')
         self.files = []
         # "walk" through BIDS directory and append all found files
-        for (dirpath, dirnames, filenames) in walk(root):
+        for (dirpath, dirnames, filenames) in walk(self.root):
             path_filenames = [join(dirpath, name) for name in filenames]
             self.files += path_filenames
 
     def test_if_valid(self):
         # for each file found, inspect if BIDS
         for file in self.files:
-            print("checking", file)
-            self.assertTrue(self.validator.is_bids(file[4:]),
-                            msg="BIDS validate failed on file" + str(file[4:]))
+            with self.subTest(file=file):
+                print("checking", file)
+                relative_path = join(sep, Path(file).relative_to(self.root))
+                self.assertTrue(self.validator.is_bids(relative_path),
+                                msg="BIDS validate failed on file "
+                                + relative_path)
 
 
 if __name__ == '__main__':

--- a/base_eeg_docker_files/environment.yml
+++ b/base_eeg_docker_files/environment.yml
@@ -40,3 +40,5 @@ dependencies:
   - ipyvtk-simple==0.1.4
   - mne-bids==0.7
   - pybv==0.5.0
+  - bids-validator==1.7.1
+  - unittest2==1.1.0


### PR DESCRIPTION
- swapped BIDSPath for OS package to get all metadata and data into testing
    - example invalid files now fail correctly:
    ```
    self.assertTrue(self.validator.is_bids(file[4:]),
    AssertionError: False is not true : 
    BIDS validate failed on file\sub-NDARAB793GL3\ses-01\eeg\sub-NDARAB793GL3-testfail.json
    ```
    - real files still pass path tests
    ```
    ----------------------------------------------------------------------
    Ran 1 test in 0.351s

    OK
    ```
    
Going off on what @yanbin-niu observed in #25, it looks like EEGLab's bid validator fails for some contents of the meta-data. 

While this merge checks the validity of the BIDS path format, perhaps another package like [bids-standard/bids-validator](https://github.com/bids-standard/bids-validator) could be added on for the next iteration of this feature to check for internal errors.