### PR TITLE
Changes to participants.tsv for BIDS compliance

### DIFF
--- a/base_eeg/import_example_data.py
+++ b/base_eeg/import_example_data.py
@@ -121,7 +121,7 @@ for b in block_df.index:
     os.remove(temp_path)
 
 # update participants.tsv
-participant_data = pd.read_csv(bids_root / 'participants.tsv', sep='\t')
+participant_data = pd.read_csv(bids_root / 'participants.tsv', sep='\t', na_filter=False)
 participant_data.loc[participant_data['participant_id'] == f'sub-{participant_code}', 'age'] = participant_age
 participant_data.loc[participant_data['participant_id'] == f'sub-{participant_code}', 'sex'] = participant_sex
-participant_data.to_csv(bids_root / 'participants.tsv', sep='\t')
+participant_data.to_csv(bids_root / 'participants.tsv', sep='\t', index=False)


### PR DESCRIPTION
We edit participants.tsv programmatically after running the mne-bids BIDS export, in order to update the participant age and sex. However importing and exporting the file was converting missing values from 'n/a' to NaN, which isn't BIDS compliant.

Two changes to support BIDS Compliance:

1. Don't convert from "n/a" to NaN on TSV import
2. Disable row indices on TSV export

Closes #102