### PR TITLE
Interpolation should read bad channels before interpolating

### DIFF
--- a/scripts/data/write.py
+++ b/scripts/data/write.py
@@ -193,9 +193,7 @@ def write_template_params(root, write_root, subjects=None, tasks=None,
         "final_reject_epoch": {
         },
         "interpolate_data": {
-            "mode": "accurate",
-            "method": None,
-            "reset_bads": None
+            "mode": "accurate"
         },
         "reref_raw": {
         }

--- a/scripts/preprocess/preprocess.py
+++ b/scripts/preprocess/preprocess.py
@@ -746,7 +746,10 @@ def interpolate_data(epochs, mode='accurate'):
     ----------
     Modified in place epochs object and output dictionary
     """
-    bads_before = epochs.info['bads']
+    try:
+        bads_before = epochs.info['bads']
+    except (TypeError, AttributeError) as error_msg:
+        return epochs, {"ERROR": str(error_msg)}
 
     if len(bads_before) == 0:
         return epochs, {"Interpolation": {"Affected": bads_before}}

--- a/scripts/preprocess/preprocess.py
+++ b/scripts/preprocess/preprocess.py
@@ -710,7 +710,7 @@ def final_reject_epoch(epochs):
     return epochs_clean, output_dict_finalRej
 
 
-def interpolate_data(epochs, mode, method, reset_bads):
+def interpolate_data(epochs, mode='accurate'):
     """Used to return an epoch object that has been interpolated
 
     Parameters:
@@ -720,12 +720,6 @@ def interpolate_data(epochs, mode, method, reset_bads):
 
     mode:   str
             Either 'accurate' or 'fast'
-
-    method: dict
-            Method to use for each channel type.
-
-    reset_bads: bool
-                If True, remove the bads from info.
 
     Throws:
     ----------
@@ -738,14 +732,17 @@ def interpolate_data(epochs, mode, method, reset_bads):
     ----------
     Modified in place epochs object and output dictionary
     """
-    try:
-        epochs.interpolate_bads(mode=mode,
-                                method=method,
-                                reset_bads=reset_bads
-                                )
-        return epochs, {"Interpolation": {"Affected": epochs.info['bads']}}
-    except (TypeError, AttributeError):
-        raise TypeError(INVALID_DATA_MSG)
+
+    bads_before = epochs.info['bads']
+
+    if len(bads_before) == 0:
+        return epochs, {"Interpolation": {"Affected": bads_before}}
+    else:
+        try:
+            epochs_interp = epochs.interpolate_bads(mode=mode)
+            return epochs_interp, {"Interpolation": {"Affected": bads_before}}
+        except (TypeError, AttributeError):
+            raise TypeError(INVALID_DATA_MSG)
 
 
 def plot_orig_and_interp(orig_raw, interp_raw):

--- a/scripts/tests/test_template_params.py
+++ b/scripts/tests/test_template_params.py
@@ -83,7 +83,7 @@ def finalReject_params():
 
 @pytest.fixture
 def interp_params():
-    return set(["mode", "method", "reset_bads"])
+    return set(["mode"])
 
 
 @pytest.fixture

--- a/user_params.json
+++ b/user_params.json
@@ -38,9 +38,7 @@
     "final_reject_epoch": {
     }, 
     "interpolate_data": {
-      "mode": "accurate", 
-      "method": null,
-      "reset_bads": true
+      "mode": "accurate"
     },
     "reref_raw": {
     }


### PR DESCRIPTION
1. Interpolation should read bad channels before interpolating. Or after interpolation, there will be no bads left;
2. Should not let user modify `reset_bads` parameter. It should always be `True`. 
3. `Method` parameter does not have to be provided as well, since the method is fixed and function would detect type automatically (MEG, EEG etc.)